### PR TITLE
Improve setting the monospaced font in the log dialog

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -35,10 +35,6 @@
 #include <QSettings>
 
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD) || defined(Q_OS_NETBSD)
-    #define OS_LINUX_OR_BSD
-#endif
-
 #ifdef Q_OS_WIN
     #define SETTINGS QSettings("cen64-qt.ini", QSettings::IniFormat)
 #else

--- a/src/logdialog.cpp
+++ b/src/logdialog.cpp
@@ -31,6 +31,10 @@
 
 #include "logdialog.h"
 
+#if QT_VERSION >= 0x050200
+#include <QFontDatabase>
+#endif
+
 
 LogDialog::LogDialog(QString lastOutput, QWidget *parent) : QDialog(parent)
 {
@@ -43,15 +47,12 @@ LogDialog::LogDialog(QString lastOutput, QWidget *parent) : QDialog(parent)
     logArea = new QTextEdit(this);
     logArea->setWordWrapMode(QTextOption::NoWrap);
 
-    QFont font;
-#ifdef OS_LINUX_OR_BSD
-    font.setFamily("Monospace");
-    font.setPointSize(9);
+#if QT_VERSION >= 0x050200
+    QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 #else
-    font.setFamily("Courier");
-    font.setPointSize(10);
+    QFont font("Monospace");
+    font.setStyleHint(QFont::TypeWriter);
 #endif
-    font.setFixedPitch(true);
     logArea->setFont(font);
 
     logArea->setPlainText(lastOutput);


### PR DESCRIPTION
This pull request improves the way a monospaced font is set in the log dialog: make more use of capabilities provided by Qt (`QFontDatabase` or defaults of `QFont`) instead of relying on platform-specific code.

Also, cleanup the `OS_LINUX_OR_BSD` macro that becomes unused.
